### PR TITLE
using new ConfigureEnvironment for windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,14 @@
 from conan.packager import ConanMultiPackager
+import platform
 
 
 if __name__ == "__main__":
     builder = ConanMultiPackager()
     builder.add_common_builds(shared_option_name="libxml2:shared", pure_c=True)
+    if platform.system() == "Windows":
+        filtered_builds = []
+        for settings, options in builder.builds:
+            if settings["os"] != "Windows" or options["libxml2:shared"] == True:
+                filtered_builds.append([settings, options])
+        builder.builds = filtered_builds
     builder.run()

--- a/build.py
+++ b/build.py
@@ -8,7 +8,8 @@ if __name__ == "__main__":
     if platform.system() == "Windows":
         filtered_builds = []
         for settings, options in builder.builds:
-            if settings["os"] != "Windows" or options["libxml2:shared"] == True:
+            print settings
+            if settings["compiler"] != "Visual Studio" or options["libxml2:shared"] == True:
                 filtered_builds.append([settings, options])
         builder.builds = filtered_builds
     builder.run()

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -18,6 +18,9 @@ class DefaultNameConan(ConanFile):
     generators = "cmake"
     requires = "libxml2/2.9.3@%s/%s" % (username, channel)
 
+    def config(self):
+        del self.settings.compiler.libcxx
+
     def build(self):
         cmake = CMake(self.settings)
         self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))


### PR DESCRIPTION
This would be the way with new ConfigureEnvironment (not yet released!):

- Not necessary to manually set vcvars in the user machine not via conan-package-tools
- Improved support for MinGW, might build if the dependencies are adapted too.